### PR TITLE
Add Keycloak authentication to frontend

### DIFF
--- a/apps/ui/vite-project/.env
+++ b/apps/ui/vite-project/.env
@@ -1,0 +1,3 @@
+VITE_KEYCLOAK_URL=http://localhost:8080/auth
+VITE_KEYCLOAK_REALM=example
+VITE_KEYCLOAK_CLIENT_ID=frontend

--- a/apps/ui/vite-project/README.md
+++ b/apps/ui/vite-project/README.md
@@ -52,3 +52,15 @@ export default tseslint.config({
   },
 })
 ```
+
+## Keycloak Authentication
+
+This project now integrates [keycloak-js](https://www.npmjs.com/package/keycloak-js) for authentication. Create a `.env` file in this directory with the following variables:
+
+```
+VITE_KEYCLOAK_URL=http://localhost:8080/auth
+VITE_KEYCLOAK_REALM=example
+VITE_KEYCLOAK_CLIENT_ID=frontend
+```
+
+When the application starts it will redirect you to Keycloak for login.

--- a/apps/ui/vite-project/package.json
+++ b/apps/ui/vite-project/package.json
@@ -25,7 +25,8 @@
     "react-redux": "^9.2.0",
     "redux": "^5.0.1",
     "redux-thunk": "^3.1.0",
-    "styled-components": "^6.1.17"
+    "styled-components": "^6.1.17",
+    "keycloak-js": "^23.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/apps/ui/vite-project/src/keycloak.ts
+++ b/apps/ui/vite-project/src/keycloak.ts
@@ -1,0 +1,9 @@
+import Keycloak from 'keycloak-js';
+
+const keycloak = new Keycloak({
+  url: import.meta.env.VITE_KEYCLOAK_URL,
+  realm: import.meta.env.VITE_KEYCLOAK_REALM,
+  clientId: import.meta.env.VITE_KEYCLOAK_CLIENT_ID,
+});
+
+export default keycloak;

--- a/apps/ui/vite-project/src/main.tsx
+++ b/apps/ui/vite-project/src/main.tsx
@@ -3,11 +3,23 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import { Provider } from 'react-redux';
 import store from './store';
+import keycloak from './keycloak';
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <Provider store={store}>
-      <App />
-    </Provider>
-  </React.StrictMode>
-);
+keycloak.onTokenExpired = () => {
+  keycloak.updateToken(30).catch(() => keycloak.login());
+};
+
+keycloak.init({ onLoad: 'login-required' }).then(authenticated => {
+  if (!authenticated) {
+    keycloak.login();
+    return;
+  }
+
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <Provider store={store}>
+        <App />
+      </Provider>
+    </React.StrictMode>,
+  );
+});


### PR DESCRIPTION
## Summary
- integrate Keycloak auth into the Vite React app
- include keycloak-js dependency
- add environment variables for Keycloak
- document Keycloak usage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*