### PR TITLE
Add client cert forward for Keycloak

### DIFF
--- a/services/caddy/Caddyfile
+++ b/services/caddy/Caddyfile
@@ -104,6 +104,8 @@
             header_up X-Forwarded-Proto {http.request.scheme}
             header_up X-Forwarded-Port {http.request.port}
             header_up X-Forwarded-Host {http.request.host}
+            # Pass along the client certificate for Keycloak when mutual TLS is used
+            header_up X-Forwarded-Client-Cert {http.request.tls.client.certificate_pem}
             header_down X-Cache-Debug "KEYCLOAK"
         }
     }


### PR DESCRIPTION
## Summary
- expose the client certificate to Keycloak using `X-Forwarded-Client-Cert`

## Testing
- `npm test -w apps/ui/vite-project` *(fails: Could not read package.json)*
- `pytest` *(fails: command not found)*